### PR TITLE
Add learning pages with navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,9 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import Grammar from "./pages/Grammar";
+import Vocabulary from "./pages/Vocabulary";
+import Listening from "./pages/Listening";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -16,6 +19,9 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/grammar" element={<Grammar />} />
+          <Route path="/vocabulary" element={<Vocabulary />} />
+          <Route path="/listening" element={<Listening />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,0 +1,48 @@
+import { Link } from 'react-router-dom';
+import { Globe } from 'lucide-react';
+import { motion } from 'framer-motion';
+
+interface HeaderProps {
+  children?: React.ReactNode;
+}
+
+const Header = ({ children }: HeaderProps) => (
+  <motion.header
+    className="sticky top-0 z-50 bg-white/80 backdrop-blur-md border-b border-violet-100"
+    initial={{ y: -50, opacity: 0 }}
+    animate={{ y: 0, opacity: 1 }}
+    transition={{ duration: 0.8, ease: 'easeOut' }}
+  >
+    <div className="container mx-auto px-4 py-4 flex items-center justify-between">
+      <Link to="/" className="flex items-center space-x-3">
+        <motion.div
+          className="w-8 h-8 bg-gradient-to-br from-violet-500 to-blue-500 rounded-full flex items-center justify-center"
+          animate={{ rotate: [0, 360] }}
+          transition={{ duration: 20, repeat: Infinity, ease: 'linear' }}
+        >
+          <Globe className="w-4 h-4 text-white" />
+        </motion.div>
+        <h1 className="text-xl font-bold bg-gradient-to-r from-violet-600 to-blue-600 bg-clip-text text-transparent">
+          BILIMAI ✨
+        </h1>
+      </Link>
+      <nav className="space-x-4 text-sm font-medium">
+        <Link to="/" className="text-gray-700 hover:text-violet-600">
+          Chat
+        </Link>
+        <Link to="/grammar" className="text-gray-700 hover:text-violet-600">
+          Grammar
+        </Link>
+        <Link to="/vocabulary" className="text-gray-700 hover:text-violet-600">
+          Vocabulary
+        </Link>
+        <Link to="/listening" className="text-gray-700 hover:text-violet-600">
+          Listening
+        </Link>
+      </nav>
+      {children}
+    </div>
+  </motion.header>
+);
+
+export default Header;

--- a/src/pages/Grammar.tsx
+++ b/src/pages/Grammar.tsx
@@ -1,0 +1,40 @@
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
+import Header from '@/components/common/Header';
+
+const topics = [
+  {
+    title: 'Tenses',
+    description: 'Learn how to express time correctly using past, present and future tenses.'
+  },
+  {
+    title: 'Articles',
+    description: 'Understand when to use a, an or the in different situations.'
+  },
+  {
+    title: 'Prepositions',
+    description: 'Master tricky prepositions with useful examples.'
+  },
+];
+
+const Grammar = () => (
+  <div className="min-h-screen bg-gradient-to-br from-violet-50 via-blue-50 to-cyan-50">
+    <Header />
+    <main className="container mx-auto px-4 py-8 max-w-3xl">
+      <h2 className="text-2xl font-semibold mb-6 text-center">Grammar Guide</h2>
+      <Accordion type="single" collapsible className="w-full bg-white/60 backdrop-blur-md rounded-2xl shadow-lg p-4">
+        {topics.map((t) => (
+          <AccordionItem value={t.title} key={t.title}>
+            <AccordionTrigger className="text-left font-medium text-violet-700">
+              {t.title}
+            </AccordionTrigger>
+            <AccordionContent className="text-gray-700 pb-4">
+              {t.description}
+            </AccordionContent>
+          </AccordionItem>
+        ))}
+      </Accordion>
+    </main>
+  </div>
+);
+
+export default Grammar;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Send, MessageCircle, Globe, BookOpen, Plane } from 'lucide-react';
 import { fetchFromDeepSeek } from '@/lib/deepseek';
+import Header from '@/components/common/Header';
 
 interface Message {
   id: string;
@@ -170,56 +171,29 @@ const Index = () => {
       </div>
 
       {/* Header */}
-      <motion.header 
-        className="sticky top-0 z-50 bg-white/80 backdrop-blur-md border-b border-violet-100"
-        initial={{ y: -50, opacity: 0 }}
-        animate={{ y: 0, opacity: 1 }}
-        transition={{ duration: 0.8, ease: "easeOut" }}
-      >
-        <div className="container mx-auto px-4 py-4">
-          <div className="flex items-center justify-between">
-            <motion.div 
-              className="flex items-center space-x-3"
-              initial={{ x: -20, opacity: 0 }}
-              animate={{ x: 0, opacity: 1 }}
-              transition={{ delay: 0.3, duration: 0.6 }}
-            >
-              <motion.div
-                className="w-10 h-10 bg-gradient-to-br from-violet-500 to-blue-500 rounded-full flex items-center justify-center"
-                animate={{ rotate: [0, 360] }}
-                transition={{ duration: 20, repeat: Infinity, ease: "linear" }}
-              >
-                <Globe className="w-5 h-5 text-white" />
-              </motion.div>
-              <h1 className="text-2xl font-bold bg-gradient-to-r from-violet-600 to-blue-600 bg-clip-text text-transparent">
-                BILIMAI ✨
-              </h1>
-            </motion.div>
-
-            <motion.div
-              initial={{ x: 20, opacity: 0 }}
-              animate={{ x: 0, opacity: 1 }}
-              transition={{ delay: 0.5, duration: 0.6 }}
-            >
-              <Select value={selectedMode} onValueChange={setSelectedMode}>
-                <SelectTrigger className="w-48 bg-white/70 border-violet-200">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent className="bg-white/95 backdrop-blur-sm">
-                  {personalityModes.map((mode) => (
-                    <SelectItem key={mode.id} value={mode.id}>
-                      <div className="flex items-center space-x-2">
-                        {mode.icon}
-                        <span>{mode.name}</span>
-                      </div>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </motion.div>
-          </div>
-        </div>
-      </motion.header>
+      <Header>
+        <motion.div
+          initial={{ x: 20, opacity: 0 }}
+          animate={{ x: 0, opacity: 1 }}
+          transition={{ delay: 0.5, duration: 0.6 }}
+        >
+          <Select value={selectedMode} onValueChange={setSelectedMode}>
+            <SelectTrigger className="w-48 bg-white/70 border-violet-200">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent className="bg-white/95 backdrop-blur-sm">
+              {personalityModes.map((mode) => (
+                <SelectItem key={mode.id} value={mode.id}>
+                  <div className="flex items-center space-x-2">
+                    {mode.icon}
+                    <span>{mode.name}</span>
+                  </div>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </motion.div>
+      </Header>
 
       {/* Chat Area */}
       <main className="container mx-auto px-4 py-6 max-w-4xl">

--- a/src/pages/Listening.tsx
+++ b/src/pages/Listening.tsx
@@ -1,0 +1,34 @@
+import Header from '@/components/common/Header';
+
+const tracks = [
+  {
+    title: 'Daily Conversation',
+    url: 'https://upload.wikimedia.org/wikipedia/commons/4/45/En-us-hello.ogg'
+  },
+  {
+    title: 'Numbers Practice',
+    url: 'https://upload.wikimedia.org/wikipedia/commons/7/70/En-us-one.ogg'
+  }
+];
+
+const Listening = () => (
+  <div className="min-h-screen bg-gradient-to-br from-violet-50 via-blue-50 to-cyan-50">
+    <Header />
+    <main className="container mx-auto px-4 py-8 max-w-3xl">
+      <h2 className="text-2xl font-semibold mb-6 text-center">Listening Practice</h2>
+      <div className="space-y-4">
+        {tracks.map((t) => (
+          <div key={t.title} className="bg-white/70 backdrop-blur-sm rounded-xl p-4 shadow">
+            <p className="font-medium text-violet-700 mb-2">{t.title}</p>
+            <audio controls className="w-full">
+              <source src={t.url} type="audio/ogg" />
+              Your browser does not support the audio element.
+            </audio>
+          </div>
+        ))}
+      </div>
+    </main>
+  </div>
+);
+
+export default Listening;

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,5 +1,6 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import Header from '@/components/common/Header';
 
 const NotFound = () => {
   const location = useLocation();
@@ -12,13 +13,16 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
-          Return to Home
-        </a>
+    <div className="min-h-screen bg-gradient-to-br from-violet-50 via-blue-50 to-cyan-50">
+      <Header />
+      <div className="flex items-center justify-center py-20">
+        <div className="text-center bg-white/70 backdrop-blur-sm p-8 rounded-xl shadow">
+          <h1 className="text-4xl font-bold mb-4">404</h1>
+          <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
+          <a href="/" className="text-violet-600 hover:underline">
+            Return to Home
+          </a>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/Vocabulary.tsx
+++ b/src/pages/Vocabulary.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import Header from '@/components/common/Header';
+
+const Vocabulary = () => {
+  const [word, setWord] = useState('');
+  const [words, setWords] = useState<string[]>([]);
+
+  const addWord = () => {
+    if (!word.trim()) return;
+    setWords([...words, word.trim()]);
+    setWord('');
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-violet-50 via-blue-50 to-cyan-50">
+      <Header />
+      <main className="container mx-auto px-4 py-8 max-w-3xl">
+        <h2 className="text-2xl font-semibold mb-6 text-center">Vocabulary Builder</h2>
+        <div className="flex space-x-2 mb-4">
+          <Input
+            value={word}
+            onChange={(e) => setWord(e.target.value)}
+            placeholder="Enter new word"
+            className="bg-white/80 backdrop-blur-sm"
+          />
+          <Button onClick={addWord} className="bg-gradient-to-r from-violet-500 to-blue-500 text-white">
+            Add
+          </Button>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {words.map((w, i) => (
+            <Badge key={i} className="px-3 py-2 bg-white/70 text-violet-700">
+              {w}
+            </Badge>
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default Vocabulary;


### PR DESCRIPTION
## Summary
- create a shared `Header` component with navigation links
- add Grammar, Vocabulary and Listening pages
- enhance NotFound page with consistent styling
- replace header markup in the chat page with new component
- register new routes in `App.tsx`

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421d9fdd1c8323a6efce941f60cb25