### PR TITLE
Add interactive flashcards and grammar quiz

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import Grammar from "./pages/Grammar";
 import Vocabulary from "./pages/Vocabulary";
 import Flashcards from "./pages/Flashcards";
 import Quiz from "./pages/Quiz";
+import QuickReview from "./pages/QuickReview";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -24,6 +25,7 @@ const App = () => (
           <Route path="/vocabulary" element={<Vocabulary />} />
           <Route path="/flashcards" element={<Flashcards />} />
           <Route path="/quiz" element={<Quiz />} />
+          <Route path="/review" element={<QuickReview />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,10 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import Grammar from "./pages/Grammar";
+import Vocabulary from "./pages/Vocabulary";
+import Flashcards from "./pages/Flashcards";
+import Quiz from "./pages/Quiz";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -16,6 +20,10 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/grammar" element={<Grammar />} />
+          <Route path="/vocabulary" element={<Vocabulary />} />
+          <Route path="/flashcards" element={<Flashcards />} />
+          <Route path="/quiz" element={<Quiz />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -42,6 +42,9 @@ const Header = ({ children }: HeaderProps) => (
         <Link to="/quiz" className="text-gray-700 hover:text-violet-600">
           Quiz
         </Link>
+        <Link to="/review" className="text-gray-700 hover:text-violet-600">
+          Review
+        </Link>
       </nav>
       {children}
     </div>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,0 +1,51 @@
+import { Link } from 'react-router-dom';
+import { Globe } from 'lucide-react';
+import { motion } from 'framer-motion';
+
+interface HeaderProps {
+  children?: React.ReactNode;
+}
+
+const Header = ({ children }: HeaderProps) => (
+  <motion.header
+    className="sticky top-0 z-50 bg-white/80 backdrop-blur-md border-b border-violet-100"
+    initial={{ y: -50, opacity: 0 }}
+    animate={{ y: 0, opacity: 1 }}
+    transition={{ duration: 0.8, ease: 'easeOut' }}
+  >
+    <div className="container mx-auto px-4 py-4 flex items-center justify-between">
+      <Link to="/" className="flex items-center space-x-3">
+        <motion.div
+          className="w-8 h-8 bg-gradient-to-br from-violet-500 to-blue-500 rounded-full flex items-center justify-center"
+          animate={{ rotate: [0, 360] }}
+          transition={{ duration: 20, repeat: Infinity, ease: 'linear' }}
+        >
+          <Globe className="w-4 h-4 text-white" />
+        </motion.div>
+        <h1 className="text-xl font-bold bg-gradient-to-r from-violet-600 to-blue-600 bg-clip-text text-transparent">
+          BILIMAI ✨
+        </h1>
+      </Link>
+      <nav className="space-x-4 text-sm font-medium">
+        <Link to="/" className="text-gray-700 hover:text-violet-600">
+          Chat
+        </Link>
+        <Link to="/grammar" className="text-gray-700 hover:text-violet-600">
+          Grammar
+        </Link>
+        <Link to="/vocabulary" className="text-gray-700 hover:text-violet-600">
+          Vocabulary
+        </Link>
+        <Link to="/flashcards" className="text-gray-700 hover:text-violet-600">
+          Flashcards
+        </Link>
+        <Link to="/quiz" className="text-gray-700 hover:text-violet-600">
+          Quiz
+        </Link>
+      </nav>
+      {children}
+    </div>
+  </motion.header>
+);
+
+export default Header;

--- a/src/data/grammar.ts
+++ b/src/data/grammar.ts
@@ -1,0 +1,51 @@
+export interface GrammarTopic {
+  title: string;
+  definition: string;
+  example: string;
+  link: string;
+}
+
+export const grammarTopics: GrammarTopic[] = [
+  {
+    title: 'Tenses',
+    definition: 'Verb tenses show the time of an action or state.',
+    example: 'I have finished my homework.',
+    link: 'https://www.ef.com/english-resources/english-grammar/verb-tenses/'
+  },
+  {
+    title: 'Conditionals',
+    definition: 'Conditionals express possibilities using if-clauses.',
+    example: 'If it rains, we\'ll stay home.',
+    link: 'https://www.perfect-english-grammar.com/conditionals.html'
+  },
+  {
+    title: 'Modal Verbs',
+    definition: 'Modals like can, must, and should show ability or obligation.',
+    example: 'She can speak three languages.',
+    link: 'https://www.ef.com/english-resources/english-grammar/modal-verbs/'
+  },
+  {
+    title: 'Articles',
+    definition: 'Articles a, an, and the define nouns as specific or unspecific.',
+    example: 'I saw a dog. The dog was brown.',
+    link: 'https://www.perfect-english-grammar.com/articles.html'
+  },
+  {
+    title: 'Prepositions',
+    definition: 'Prepositions show relationships between words in a sentence.',
+    example: 'The book is on the table.',
+    link: 'https://www.ef.com/english-resources/english-grammar/prepositions/'
+  },
+  {
+    title: 'Passive Voice',
+    definition: 'In passive voice, the subject receives the action.',
+    example: 'The cake was eaten by the children.',
+    link: 'https://www.perfect-english-grammar.com/passive.html'
+  },
+  {
+    title: 'Gerunds & Infinitives',
+    definition: 'Gerunds end in -ing and infinitives use to + verb.',
+    example: 'I enjoy swimming. I want to swim.',
+    link: 'https://www.ef.com/english-resources/english-grammar/gerund-infinitive/'
+  }
+];

--- a/src/pages/Flashcards.tsx
+++ b/src/pages/Flashcards.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import Header from '@/components/common/Header';
 import { fetchFromDeepSeek } from '@/lib/deepseek';
+import { motion } from 'framer-motion';
 
 interface Card {
   word: string;
@@ -13,6 +14,17 @@ const Flashcards = () => {
   const [term, setTerm] = useState('');
   const [cards, setCards] = useState<Card[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('flashcards');
+    if (stored) {
+      setCards(JSON.parse(stored));
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('flashcards', JSON.stringify(cards));
+  }, [cards]);
 
   const addCard = async () => {
     if (!term.trim()) return;
@@ -29,6 +41,10 @@ const Flashcards = () => {
     } finally {
       setIsLoading(false);
     }
+  };
+
+  const removeCard = (index: number) => {
+    setCards(cards.filter((_, i) => i !== index));
   };
 
   return (
@@ -53,10 +69,25 @@ const Flashcards = () => {
         </div>
         <div className="space-y-4">
           {cards.map((c, i) => (
-            <div key={i} className="bg-white/70 backdrop-blur-sm p-4 rounded-xl shadow">
-              <p className="font-medium text-violet-700 mb-1">{c.word}</p>
-              <p className="text-gray-700 whitespace-pre-line">{c.meaning}</p>
-            </div>
+            <motion.div
+              key={i}
+              className="bg-white/70 backdrop-blur-sm p-4 rounded-xl shadow flex justify-between items-start"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+            >
+              <div>
+                <p className="font-medium text-violet-700 mb-1">{c.word}</p>
+                <p className="text-gray-700 whitespace-pre-line">{c.meaning}</p>
+              </div>
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={() => removeCard(i)}
+                className="ml-2"
+              >
+                ✕
+              </Button>
+            </motion.div>
           ))}
         </div>
       </main>

--- a/src/pages/Flashcards.tsx
+++ b/src/pages/Flashcards.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import Header from '@/components/common/Header';
+import { fetchFromDeepSeek } from '@/lib/deepseek';
+
+interface Card {
+  word: string;
+  meaning: string;
+}
+
+const Flashcards = () => {
+  const [term, setTerm] = useState('');
+  const [cards, setCards] = useState<Card[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const addCard = async () => {
+    if (!term.trim()) return;
+    setIsLoading(true);
+    try {
+      const res = await fetchFromDeepSeek(
+        `Give a short definition and example sentence for the word "${term.trim()}". Format as: definition - example.`,
+        'You are a helpful language tutor created by Emilbek. Respond concisely.'
+      );
+      setCards([...cards, { word: term.trim(), meaning: res.trim() }]);
+      setTerm('');
+    } catch (error) {
+      console.error('Failed to add card:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-violet-50 via-blue-50 to-cyan-50">
+      <Header />
+      <main className="container mx-auto px-4 py-8 max-w-3xl">
+        <h2 className="text-2xl font-semibold mb-6 text-center">Flashcards</h2>
+        <div className="flex space-x-2 mb-4">
+          <Input
+            value={term}
+            onChange={(e) => setTerm(e.target.value)}
+            placeholder="Enter new word or phrase"
+            className="bg-white/80 backdrop-blur-sm"
+          />
+          <Button
+            onClick={addCard}
+            disabled={!term.trim() || isLoading}
+            className="bg-gradient-to-r from-violet-500 to-blue-500 text-white"
+          >
+            {isLoading ? 'Adding...' : 'Add'}
+          </Button>
+        </div>
+        <div className="space-y-4">
+          {cards.map((c, i) => (
+            <div key={i} className="bg-white/70 backdrop-blur-sm p-4 rounded-xl shadow">
+              <p className="font-medium text-violet-700 mb-1">{c.word}</p>
+              <p className="text-gray-700 whitespace-pre-line">{c.meaning}</p>
+            </div>
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default Flashcards;

--- a/src/pages/Grammar.tsx
+++ b/src/pages/Grammar.tsx
@@ -1,24 +1,16 @@
 import { useState } from 'react';
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger
+} from '@/components/ui/accordion';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import Header from '@/components/common/Header';
 import { fetchFromDeepSeek } from '@/lib/deepseek';
+import { grammarTopics } from '@/data/grammar';
 
-const topics = [
-  {
-    title: 'Tenses',
-    description: 'Learn how to express time correctly using past, present and future tenses.'
-  },
-  {
-    title: 'Articles',
-    description: 'Understand when to use a, an or the in different situations.'
-  },
-  {
-    title: 'Prepositions',
-    description: 'Master tricky prepositions with useful examples.'
-  },
-];
 
 const Grammar = () => {
   const [question, setQuestion] = useState('');
@@ -44,14 +36,27 @@ const Grammar = () => {
       <Header />
       <main className="container mx-auto px-4 py-8 max-w-3xl">
         <h2 className="text-2xl font-semibold mb-6 text-center">Grammar Guide</h2>
-        <Accordion type="single" collapsible className="w-full bg-white/60 backdrop-blur-md rounded-2xl shadow-lg p-4 mb-8">
-          {topics.map((t) => (
+        <Accordion
+          type="single"
+          collapsible
+          className="w-full bg-white/60 backdrop-blur-md rounded-2xl shadow-lg p-4 mb-8"
+        >
+          {grammarTopics.map((t) => (
             <AccordionItem value={t.title} key={t.title}>
               <AccordionTrigger className="text-left font-medium text-violet-700">
                 {t.title}
               </AccordionTrigger>
-              <AccordionContent className="text-gray-700 pb-4">
-                {t.description}
+              <AccordionContent className="text-gray-700 pb-4 space-y-2">
+                <p>{t.definition}</p>
+                <p className="italic text-sm">Example: {t.example}</p>
+                <a
+                  href={t.link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-violet-600 hover:underline"
+                >
+                  Learn more
+                </a>
               </AccordionContent>
             </AccordionItem>
           ))}

--- a/src/pages/Grammar.tsx
+++ b/src/pages/Grammar.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import Header from '@/components/common/Header';
+import { fetchFromDeepSeek } from '@/lib/deepseek';
+
+const topics = [
+  {
+    title: 'Tenses',
+    description: 'Learn how to express time correctly using past, present and future tenses.'
+  },
+  {
+    title: 'Articles',
+    description: 'Understand when to use a, an or the in different situations.'
+  },
+  {
+    title: 'Prepositions',
+    description: 'Master tricky prepositions with useful examples.'
+  },
+];
+
+const Grammar = () => {
+  const [question, setQuestion] = useState('');
+  const [answer, setAnswer] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const ask = async () => {
+    if (!question.trim()) return;
+    setLoading(true);
+    try {
+      const res = await fetchFromDeepSeek(question, 'You are a grammar expert created by Emilbek. Answer clearly.');
+      setAnswer(res);
+      setQuestion('');
+    } catch (err) {
+      console.error('Failed to get answer:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-violet-50 via-blue-50 to-cyan-50">
+      <Header />
+      <main className="container mx-auto px-4 py-8 max-w-3xl">
+        <h2 className="text-2xl font-semibold mb-6 text-center">Grammar Guide</h2>
+        <Accordion type="single" collapsible className="w-full bg-white/60 backdrop-blur-md rounded-2xl shadow-lg p-4 mb-8">
+          {topics.map((t) => (
+            <AccordionItem value={t.title} key={t.title}>
+              <AccordionTrigger className="text-left font-medium text-violet-700">
+                {t.title}
+              </AccordionTrigger>
+              <AccordionContent className="text-gray-700 pb-4">
+                {t.description}
+              </AccordionContent>
+            </AccordionItem>
+          ))}
+        </Accordion>
+        <div className="space-y-4 bg-white/70 backdrop-blur-sm p-6 rounded-xl shadow">
+          <p className="font-medium text-violet-700">Ask a grammar question</p>
+          <Input
+            value={question}
+            onChange={(e) => setQuestion(e.target.value)}
+            placeholder="Type your question"
+            className="bg-white/80"
+          />
+          <Button onClick={ask} disabled={!question.trim() || loading} className="bg-gradient-to-r from-violet-500 to-blue-500 text-white">
+            {loading ? 'Loading...' : 'Ask'}
+          </Button>
+          {answer && <p className="text-gray-700 whitespace-pre-line">{answer}</p>}
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default Grammar;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Send, MessageCircle, Globe, BookOpen, Plane } from 'lucide-react';
 import { fetchFromDeepSeek } from '@/lib/deepseek';
+import Header from '@/components/common/Header';
 
 interface Message {
   id: string;
@@ -170,56 +171,29 @@ const Index = () => {
       </div>
 
       {/* Header */}
-      <motion.header 
-        className="sticky top-0 z-50 bg-white/80 backdrop-blur-md border-b border-violet-100"
-        initial={{ y: -50, opacity: 0 }}
-        animate={{ y: 0, opacity: 1 }}
-        transition={{ duration: 0.8, ease: "easeOut" }}
-      >
-        <div className="container mx-auto px-4 py-4">
-          <div className="flex items-center justify-between">
-            <motion.div 
-              className="flex items-center space-x-3"
-              initial={{ x: -20, opacity: 0 }}
-              animate={{ x: 0, opacity: 1 }}
-              transition={{ delay: 0.3, duration: 0.6 }}
-            >
-              <motion.div
-                className="w-10 h-10 bg-gradient-to-br from-violet-500 to-blue-500 rounded-full flex items-center justify-center"
-                animate={{ rotate: [0, 360] }}
-                transition={{ duration: 20, repeat: Infinity, ease: "linear" }}
-              >
-                <Globe className="w-5 h-5 text-white" />
-              </motion.div>
-              <h1 className="text-2xl font-bold bg-gradient-to-r from-violet-600 to-blue-600 bg-clip-text text-transparent">
-                BILIMAI ✨
-              </h1>
-            </motion.div>
-
-            <motion.div
-              initial={{ x: 20, opacity: 0 }}
-              animate={{ x: 0, opacity: 1 }}
-              transition={{ delay: 0.5, duration: 0.6 }}
-            >
-              <Select value={selectedMode} onValueChange={setSelectedMode}>
-                <SelectTrigger className="w-48 bg-white/70 border-violet-200">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent className="bg-white/95 backdrop-blur-sm">
-                  {personalityModes.map((mode) => (
-                    <SelectItem key={mode.id} value={mode.id}>
-                      <div className="flex items-center space-x-2">
-                        {mode.icon}
-                        <span>{mode.name}</span>
-                      </div>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </motion.div>
-          </div>
-        </div>
-      </motion.header>
+      <Header>
+        <motion.div
+          initial={{ x: 20, opacity: 0 }}
+          animate={{ x: 0, opacity: 1 }}
+          transition={{ delay: 0.5, duration: 0.6 }}
+        >
+          <Select value={selectedMode} onValueChange={setSelectedMode}>
+            <SelectTrigger className="w-48 bg-white/70 border-violet-200">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent className="bg-white/95 backdrop-blur-sm">
+              {personalityModes.map((mode) => (
+                <SelectItem key={mode.id} value={mode.id}>
+                  <div className="flex items-center space-x-2">
+                    {mode.icon}
+                    <span>{mode.name}</span>
+                  </div>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </motion.div>
+      </Header>
 
       {/* Chat Area */}
       <main className="container mx-auto px-4 py-6 max-w-4xl">

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,5 +1,6 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import Header from '@/components/common/Header';
 
 const NotFound = () => {
   const location = useLocation();
@@ -12,13 +13,16 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
-          Return to Home
-        </a>
+    <div className="min-h-screen bg-gradient-to-br from-violet-50 via-blue-50 to-cyan-50">
+      <Header />
+      <div className="flex items-center justify-center py-20">
+        <div className="text-center bg-white/70 backdrop-blur-sm p-8 rounded-xl shadow">
+          <h1 className="text-4xl font-bold mb-4">404</h1>
+          <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
+          <a href="/" className="text-violet-600 hover:underline">
+            Return to Home
+          </a>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/QuickReview.tsx
+++ b/src/pages/QuickReview.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import Header from '@/components/common/Header';
+import { Button } from '@/components/ui/button';
+import { grammarTopics } from '@/data/grammar';
+import { motion } from 'framer-motion';
+
+interface ReviewItem {
+  term: string;
+  info: string;
+}
+
+const QuickReview = () => {
+  const [items, setItems] = useState<ReviewItem[]>([]);
+
+  const load = () => {
+    const vocabs = JSON.parse(localStorage.getItem('vocabulary') || '[]') as { term: string; info: string }[];
+    const combined: ReviewItem[] = [
+      ...vocabs.map(v => ({ term: v.term, info: v.info })),
+      ...grammarTopics.map(g => ({ term: g.title, info: g.definition }))
+    ];
+    const shuffled = combined.sort(() => 0.5 - Math.random()).slice(0, 5);
+    setItems(shuffled);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-violet-50 via-blue-50 to-cyan-50">
+      <Header />
+      <main className="container mx-auto px-4 py-8 max-w-3xl">
+        <h2 className="text-2xl font-semibold mb-6 text-center">Quick Review</h2>
+        <Button onClick={load} className="mb-4 bg-gradient-to-r from-violet-500 to-blue-500 text-white">
+          Shuffle
+        </Button>
+        <div className="space-y-4">
+          {items.map((item, i) => (
+            <motion.div
+              key={i}
+              className="bg-white/70 backdrop-blur-sm p-4 rounded-xl shadow"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+            >
+              <p className="font-medium text-violet-700 mb-1">{item.term}</p>
+              <p className="text-gray-700 whitespace-pre-line">{item.info}</p>
+            </motion.div>
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default QuickReview;

--- a/src/pages/Quiz.tsx
+++ b/src/pages/Quiz.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import Header from '@/components/common/Header';
+import { fetchFromDeepSeek } from '@/lib/deepseek';
+
+interface Question {
+  question: string;
+  options: string[];
+  answer: string;
+}
+
+const Quiz = () => {
+  const [current, setCurrent] = useState<Question | null>(null);
+  const [selected, setSelected] = useState('');
+  const [result, setResult] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const generateQuestion = async () => {
+    setLoading(true);
+    setSelected('');
+    setResult('');
+    try {
+      const prompt =
+        'Create a short multiple choice grammar question for English learners. Respond in JSON with keys question, options, answer.';
+      const data = await fetchFromDeepSeek(prompt, 'You are a grammar quiz generator created by Emilbek.');
+      const parsed = JSON.parse(data);
+      setCurrent(parsed);
+    } catch (error) {
+      console.error('Failed to generate question:', error);
+      setCurrent(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const checkAnswer = (option: string) => {
+    if (!current) return;
+    setSelected(option);
+    if (option === current.answer) {
+      setResult('Correct!');
+    } else {
+      setResult(`Incorrect. Correct answer: ${current.answer}`);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-violet-50 via-blue-50 to-cyan-50">
+      <Header />
+      <main className="container mx-auto px-4 py-8 max-w-3xl">
+        <h2 className="text-2xl font-semibold mb-6 text-center">Grammar Quiz</h2>
+        <Button onClick={generateQuestion} className="mb-4 bg-gradient-to-r from-violet-500 to-blue-500 text-white">
+          {loading ? 'Loading...' : current ? 'Next Question' : 'Start Quiz'}
+        </Button>
+        {current && (
+          <div className="bg-white/70 backdrop-blur-sm rounded-xl p-6 shadow space-y-4">
+            <p className="font-medium text-violet-700">{current.question}</p>
+            <div className="space-y-2">
+              {current.options.map((opt) => (
+                <Button
+                  key={opt}
+                  variant="outline"
+                  onClick={() => checkAnswer(opt)}
+                  disabled={!!result || loading}
+                  className="w-full"
+                >
+                  {opt}
+                </Button>
+              ))}
+            </div>
+            {result && <p className="font-semibold">{result}</p>}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+};
+
+export default Quiz;

--- a/src/pages/Vocabulary.tsx
+++ b/src/pages/Vocabulary.tsx
@@ -1,9 +1,9 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import Header from '@/components/common/Header';
 import { fetchFromDeepSeek } from '@/lib/deepseek';
+import { motion } from 'framer-motion';
 
 interface VocabItem {
   term: string;
@@ -14,6 +14,17 @@ const Vocabulary = () => {
   const [word, setWord] = useState('');
   const [items, setItems] = useState<VocabItem[]>([]);
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('vocabulary');
+    if (stored) {
+      setItems(JSON.parse(stored));
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('vocabulary', JSON.stringify(items));
+  }, [items]);
 
   const addWord = async () => {
     if (!word.trim()) return;
@@ -30,6 +41,10 @@ const Vocabulary = () => {
     } finally {
       setLoading(false);
     }
+  };
+
+  const removeItem = (index: number) => {
+    setItems(items.filter((_, i) => i !== index));
   };
 
   return (
@@ -50,10 +65,25 @@ const Vocabulary = () => {
         </div>
         <div className="space-y-4">
           {items.map((item, i) => (
-            <div key={i} className="bg-white/70 backdrop-blur-sm p-4 rounded-xl shadow">
-              <p className="font-medium text-violet-700 mb-1">{item.term}</p>
-              <p className="text-gray-700 whitespace-pre-line">{item.info}</p>
-            </div>
+            <motion.div
+              key={i}
+              className="bg-white/70 backdrop-blur-sm p-4 rounded-xl shadow flex justify-between items-start"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+            >
+              <div>
+                <p className="font-medium text-violet-700 mb-1">{item.term}</p>
+                <p className="text-gray-700 whitespace-pre-line">{item.info}</p>
+              </div>
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={() => removeItem(i)}
+                className="ml-2"
+              >
+                ✕
+              </Button>
+            </motion.div>
           ))}
         </div>
       </main>

--- a/src/pages/Vocabulary.tsx
+++ b/src/pages/Vocabulary.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import Header from '@/components/common/Header';
+import { fetchFromDeepSeek } from '@/lib/deepseek';
+
+interface VocabItem {
+  term: string;
+  info: string;
+}
+
+const Vocabulary = () => {
+  const [word, setWord] = useState('');
+  const [items, setItems] = useState<VocabItem[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const addWord = async () => {
+    if (!word.trim()) return;
+    setLoading(true);
+    try {
+      const res = await fetchFromDeepSeek(
+        `Explain the meaning of "${word.trim()}" and provide a short example sentence.`,
+        'You are a helpful language tutor created by Emilbek. Be concise.'
+      );
+      setItems([...items, { term: word.trim(), info: res.trim() }]);
+      setWord('');
+    } catch (error) {
+      console.error('Failed to fetch info:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-violet-50 via-blue-50 to-cyan-50">
+      <Header />
+      <main className="container mx-auto px-4 py-8 max-w-3xl">
+        <h2 className="text-2xl font-semibold mb-6 text-center">Vocabulary Builder</h2>
+        <div className="flex space-x-2 mb-4">
+          <Input
+            value={word}
+            onChange={(e) => setWord(e.target.value)}
+            placeholder="Enter new word"
+            className="bg-white/80 backdrop-blur-sm"
+          />
+          <Button onClick={addWord} disabled={!word.trim() || loading} className="bg-gradient-to-r from-violet-500 to-blue-500 text-white">
+            {loading ? 'Adding...' : 'Add'}
+          </Button>
+        </div>
+        <div className="space-y-4">
+          {items.map((item, i) => (
+            <div key={i} className="bg-white/70 backdrop-blur-sm p-4 rounded-xl shadow">
+              <p className="font-medium text-violet-700 mb-1">{item.term}</p>
+              <p className="text-gray-700 whitespace-pre-line">{item.info}</p>
+            </div>
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default Vocabulary;


### PR DESCRIPTION
## Summary
- replace Listening with new Flashcards and Quiz pages
- update routing and navigation links
- expand Grammar page with an AI-powered Q&A section
- enhance Vocabulary builder with API-generated info

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421d9fdd1c8323a6efce941f60cb25