### PR TITLE
Implement hash-based routing and simple login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,10 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { HashRouter, Routes, Route } from "react-router-dom";
+import { AuthProvider } from "@/hooks/use-auth";
+import ProtectedRoute from "@/components/common/ProtectedRoute";
+import Login from "./pages/Login";
 import Index from "./pages/Index";
 import Grammar from "./pages/Grammar";
 import Vocabulary from "./pages/Vocabulary";
@@ -12,22 +15,53 @@ import NotFound from "./pages/NotFound";
 const queryClient = new QueryClient();
 
 const App = () => (
-  <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          <Route path="/grammar" element={<Grammar />} />
-          <Route path="/vocabulary" element={<Vocabulary />} />
-          <Route path="/listening" element={<Listening />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
-    </TooltipProvider>
-  </QueryClientProvider>
+  <AuthProvider>
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <Toaster />
+        <Sonner />
+        <HashRouter>
+          <Routes>
+            <Route path="/login" element={<Login />} />
+            <Route
+              path="/"
+              element={
+                <ProtectedRoute>
+                  <Index />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/grammar"
+              element={
+                <ProtectedRoute>
+                  <Grammar />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/vocabulary"
+              element={
+                <ProtectedRoute>
+                  <Vocabulary />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/listening"
+              element={
+                <ProtectedRoute>
+                  <Listening />
+                </ProtectedRoute>
+              }
+            />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </HashRouter>
+      </TooltipProvider>
+    </QueryClientProvider>
+  </AuthProvider>
 );
 
 export default App;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,48 +1,61 @@
 import { Link } from 'react-router-dom';
 import { Globe } from 'lucide-react';
 import { motion } from 'framer-motion';
+import { useAuth } from '@/hooks/use-auth';
 
 interface HeaderProps {
   children?: React.ReactNode;
 }
 
-const Header = ({ children }: HeaderProps) => (
-  <motion.header
-    className="sticky top-0 z-50 bg-white/80 backdrop-blur-md border-b border-violet-100"
-    initial={{ y: -50, opacity: 0 }}
-    animate={{ y: 0, opacity: 1 }}
-    transition={{ duration: 0.8, ease: 'easeOut' }}
-  >
-    <div className="container mx-auto px-4 py-4 flex items-center justify-between">
-      <Link to="/" className="flex items-center space-x-3">
-        <motion.div
-          className="w-8 h-8 bg-gradient-to-br from-violet-500 to-blue-500 rounded-full flex items-center justify-center"
-          animate={{ rotate: [0, 360] }}
-          transition={{ duration: 20, repeat: Infinity, ease: 'linear' }}
-        >
-          <Globe className="w-4 h-4 text-white" />
-        </motion.div>
-        <h1 className="text-xl font-bold bg-gradient-to-r from-violet-600 to-blue-600 bg-clip-text text-transparent">
-          BILIMAI ✨
-        </h1>
-      </Link>
-      <nav className="space-x-4 text-sm font-medium">
-        <Link to="/" className="text-gray-700 hover:text-violet-600">
-          Chat
+const Header = ({ children }: HeaderProps) => {
+  const { isAuthenticated, logout } = useAuth();
+  return (
+    <motion.header
+      className="sticky top-0 z-50 bg-white/80 backdrop-blur-md border-b border-violet-100"
+      initial={{ y: -50, opacity: 0 }}
+      animate={{ y: 0, opacity: 1 }}
+      transition={{ duration: 0.8, ease: 'easeOut' }}
+    >
+      <div className="container mx-auto px-4 py-4 flex items-center justify-between">
+        <Link to="/" className="flex items-center space-x-3">
+          <motion.div
+            className="w-8 h-8 bg-gradient-to-br from-violet-500 to-blue-500 rounded-full flex items-center justify-center"
+            animate={{ rotate: [0, 360] }}
+            transition={{ duration: 20, repeat: Infinity, ease: 'linear' }}
+          >
+            <Globe className="w-4 h-4 text-white" />
+          </motion.div>
+          <h1 className="text-xl font-bold bg-gradient-to-r from-violet-600 to-blue-600 bg-clip-text text-transparent">
+            BILIMAI ✨
+          </h1>
         </Link>
-        <Link to="/grammar" className="text-gray-700 hover:text-violet-600">
-          Grammar
-        </Link>
-        <Link to="/vocabulary" className="text-gray-700 hover:text-violet-600">
-          Vocabulary
-        </Link>
-        <Link to="/listening" className="text-gray-700 hover:text-violet-600">
-          Listening
-        </Link>
-      </nav>
-      {children}
-    </div>
-  </motion.header>
-);
+        <nav className="space-x-4 text-sm font-medium">
+          <Link to="/" className="text-gray-700 hover:text-violet-600">
+            Chat
+          </Link>
+          <Link to="/grammar" className="text-gray-700 hover:text-violet-600">
+            Grammar
+          </Link>
+          <Link to="/vocabulary" className="text-gray-700 hover:text-violet-600">
+            Vocabulary
+          </Link>
+          <Link to="/listening" className="text-gray-700 hover:text-violet-600">
+            Listening
+          </Link>
+          {isAuthenticated ? (
+            <button onClick={logout} className="text-gray-700 hover:text-violet-600">
+              Logout
+            </button>
+          ) : (
+            <Link to="/login" className="text-gray-700 hover:text-violet-600">
+              Login
+            </Link>
+          )}
+        </nav>
+        {children}
+      </div>
+    </motion.header>
+  );
+};
 
 export default Header;

--- a/src/components/common/ProtectedRoute.tsx
+++ b/src/components/common/ProtectedRoute.tsx
@@ -1,0 +1,12 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "@/hooks/use-auth";
+
+const ProtectedRoute = ({ children }: { children: JSX.Element }) => {
+  const { isAuthenticated } = useAuth();
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+  return children;
+};
+
+export default ProtectedRoute;

--- a/src/hooks/use-auth.tsx
+++ b/src/hooks/use-auth.tsx
@@ -1,0 +1,40 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+interface AuthContextType {
+  isAuthenticated: boolean;
+  login: () => void;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("authenticated");
+    setIsAuthenticated(stored === "true");
+  }, []);
+
+  const login = () => {
+    localStorage.setItem("authenticated", "true");
+    setIsAuthenticated(true);
+  };
+
+  const logout = () => {
+    localStorage.removeItem("authenticated");
+    setIsAuthenticated(false);
+  };
+
+  return (
+    <AuthContext.Provider value={{ isAuthenticated, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+};

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import Header from "@/components/common/Header";
+import { useAuth } from "@/hooks/use-auth";
+
+const Login = () => {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    login();
+    navigate("/");
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-violet-50 via-blue-50 to-cyan-50 flex flex-col">
+      <Header />
+      <div className="flex flex-1 items-center justify-center">
+        <form onSubmit={handleSubmit} className="bg-white/70 backdrop-blur-md p-8 rounded-xl shadow-md w-80 space-y-4">
+          <h2 className="text-xl font-bold text-center">Login</h2>
+          <Input placeholder="Username" value={username} onChange={(e) => setUsername(e.target.value)} />
+          <Input type="password" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} />
+          <Button type="submit" className="w-full">Login</Button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default Login;


### PR DESCRIPTION
## Summary
- switch to `HashRouter` to avoid 404s on page refresh
- create `use-auth` hook with `AuthProvider`
- add `ProtectedRoute` component
- add login page and integrate login/logout into header
- guard application routes with authentication

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68427ad7bbdc83238c90570f7464064c